### PR TITLE
Fixed "Overload resolution failed" Error

### DIFF
--- a/code/pattern_generation/graphics_cv2.py
+++ b/code/pattern_generation/graphics_cv2.py
@@ -8,15 +8,20 @@ SCALAR = 50
 
 def draw_tile(tile, image, offset_coord=Vector(0, 0)):
     fill = tile[1][1]
+    # 确保 fill 是元组格式 (B, G, R)
+    if isinstance(fill, list):
+        fill = tuple(fill)
+        
     vertices = np.zeros((len(tile[0]), 2))
     
     for i in range (0, len(tile[0])):
         vertices[i][0] = tile[0][i].x*SCALAR - offset_coord.x*OUTPUT_IMAGE_DIMENSIONS.x
         vertices[i][1] = tile[0][i].y*SCALAR + OUTPUT_IMAGE_DIMENSIONS.y + offset_coord.y*OUTPUT_IMAGE_DIMENSIONS.y
 
-    vertices = vertices.astype(int)
-    #vertices = vertices.reshape((-1, 1, 2))
+    # 显式转换为 int32，这是 OpenCV 最兼容的类型
+    vertices = vertices.astype(np.int32) 
 
-    output_image = cv2.fillPoly(image, pts=[vertices], color=fill)
-    output_image = cv2.polylines(image, [vertices], True, (0, 0, 0), 2)
-    return output_image
+    # OpenCV 直接修改原图，不需要写 output_image = ...
+    cv2.fillPoly(image, pts=[vertices], color=fill)
+    cv2.polylines(image, [vertices], True, (0, 0, 0), 2)
+    return image

--- a/code/pattern_generation/main.py
+++ b/code/pattern_generation/main.py
@@ -1,7 +1,7 @@
 from pattern_generator import *
 from graphics_tk import *
 
-SCALAR = 30
+SCALAR = 8
 
 while True:
     next_generation()

--- a/code/pattern_generation/seed_to_pattern.py
+++ b/code/pattern_generation/seed_to_pattern.py
@@ -51,7 +51,7 @@ def seed_to_pattern(seed, output_file_name="output.png"):
     next_generation()
     
     while True:
-        output_image = np.full((OUTPUT_IMAGE_DIMENSIONS.y, OUTPUT_IMAGE_DIMENSIONS.x, 3), 255)
+        output_image = np.full((OUTPUT_IMAGE_DIMENSIONS.y, OUTPUT_IMAGE_DIMENSIONS.x, 3), 255, dtype=np.uint8)
         for tile in vertices_to_draw:
             output_image = draw_tile(tile, output_image, offset_coord=offset_coordinate)
 


### PR DESCRIPTION
# Feb 11, 2026 12:33 UTC+08:00

## Origin Error

```CMD
C:\Users\BAIJIANG\Documents\Einstein_Tile_Generator-main\code\pattern_generation>python seed_to_pattern.py
Traceback (most recent call last):
  File "C:\Users\BAIJIANG\Documents\Einstein_Tile_Generator-main\code\pattern_generation\seed_to_pattern.py", line 65, in <module>
    seed_to_pattern(6)
    ~~~~~~~~~~~~~~~^^^
  File "C:\Users\BAIJIANG\Documents\Einstein_Tile_Generator-main\code\pattern_generation\seed_to_pattern.py", line 56, in seed_to_pattern
    output_image = draw_tile(tile, output_image, offset_coord=offset_coordinate)
  File "C:\Users\BAIJIANG\Documents\Einstein_Tile_Generator-main\code\pattern_generation\graphics_cv2.py", line 20, in draw_tile
    output_image = cv2.fillPoly(image, pts=[vertices], color=fill)
cv2.error: OpenCV(4.13.0) :-1: error: (-5:Bad argument) in function 'fillPoly'
> Overload resolution failed:
>  - Layout of the output array img is incompatible with cv::Mat
>  - Expected Ptr<cv::UMat> for argument 'img'
```

## Here I changed these

1. added `dtype=np.uint8` at `output_image = np.full((OUTPUT_IMAGE_DIMENSIONS.y, OUTPUT_IMAGE_DIMENSIONS.x, 3), 255)` in function `seed_to_pattern` in `seed_to_pattern.py`
2. changed `SCALAR = 30` to `SCALAR = 8` in `main.py`
3. rewrite `draw_tile` in `graphics_cv2.py`